### PR TITLE
fix copy function in util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -133,12 +133,21 @@ function copy(from, to, files, callback) {
         var basePath
             , hasStar = /\*\*\/\*/.test(includeRule);
 
+        /*
+         * if we're not using globs as a rule for file inclusion
+         * we need to handle a few use cases to ensure proper
+         * copy functionality
+         */
         if(!hasStar) {
 
-            basePath = path.join(
-                from,
-                (!includeRule.substring(0, 2) == './' || files.basePath ? '' : path.dirname(includeRule))
-            );
+            //user wants to preserve directory structure
+            if(includeRule.substring(0, 2) == './' ) {
+                basePath = from;
+            }
+            //do not preserve the structure
+            else {
+                basePath = path.resolve(from,path.dirname(includeRule));
+            }
         }
         else {
             basePath = from;


### PR DESCRIPTION
we needed to use path.resolve
and not worry about the existence of files.basepath
