### PR TITLE
Avoid rebasing in remote sync strategy

### DIFF
--- a/lib/libgrabber.js
+++ b/lib/libgrabber.js
@@ -88,9 +88,11 @@ function update(jsDelivrPath, metadataPath, callback) {
 function syncRepo(callback) {
   var repo = gift(config.get('jsdelivr-path'));
   repo.checkout('master', function () {
-    repo.git.cmd('pull', {}, ['--rebase', 'upstream', 'master'], function () {
-      repo.git.cmd('push', {}, ['--force', 'origin', 'master'], function () {
-        callback(null);
+    repo.remote_fetch('upstream', function() {
+      repo.reset('upstream/master', {hard: true}, function () {
+        repo.git.cmd('push', {}, ['--force', 'origin', 'master'], function () {
+          callback(null);
+        });
       });
     });
   });


### PR DESCRIPTION
This should avoid the constant "merge branch" in pull requests. 
E.g. https://github.com/jsdelivr/jsdelivr/pull/5330#issuecomment-112612854

/cc @UnbounDev 