### PR TITLE
Optimize synchronization strategy

### DIFF
--- a/lib/libgrabber.js
+++ b/lib/libgrabber.js
@@ -34,7 +34,10 @@ function updateAll(jsDelivrPath, projectsPath,projectToUpdate) {
         });
       }
 
-      reduceReposToUpdate(metadataPaths, function(projects) {
+      reduceReposToUpdate(metadataPaths, function(err, projects) {
+        if (err) {
+          return logger.error(err);
+        }
         async.eachSeries(projects, function (proj, callback) {
           update(jsDelivrPath, proj, function (err, result) {
             if (err) {
@@ -62,14 +65,13 @@ function traverse(projectsPath, callback) {
 
 // Determine all of the repos that should be updated (in parallel)
 function reduceReposToUpdate(paths, callback) {
-  async.mapLimit(paths, 20, project.check, function(projects) {
-    callback(null, _.filter(projects, 'updateRemote'));
+  async.mapLimit(paths, 20, project.check, function(err, projects) {
+    callback(err, _.filter(projects, 'updateRemote'));
   });
 }
 
-function update(proj, jsDelivrPath, callback) {
+function update(jsDelivrPath, proj, callback) {
   logger.debug('Updating using metadata %s', proj.metadataPath);
-
   async.waterfall([
     async.apply(project.update, proj),
     async.apply(project.commit, jsDelivrPath),

--- a/lib/libgrabber.js
+++ b/lib/libgrabber.js
@@ -28,28 +28,29 @@ function updateAll(jsDelivrPath, projectsPath,projectToUpdate) {
         throw err;
       }
 
-      async.eachLimit(metadataPaths, 1, function (metadataPath, callback) {
+      if (projectToUpdate_metaDataPath) {
+        metadataPaths = _.filter(metadataPaths, function(path) {
+          return projectToUpdate_metaDataPath === path;
+        });
+      }
 
-          if(!projectToUpdate_metaDataPath || projectToUpdate_metaDataPath == metadataPath) {
-            update(jsDelivrPath, metadataPath, function (err, result) {
-              if (err) {
-                  // suppress error from propagating and go on with the next project
-                  logger.error('Failed to update project', { error: err });
-              }
+      reduceReposToUpdate(metadataPaths, function(projects) {
+        async.eachSeries(projects, function (proj, callback) {
+          update(jsDelivrPath, proj, function (err, result) {
+            if (err) {
+                // suppress error from propagating and go on with the next project
+                logger.error('Failed to update project', { error: err });
+            }
 
-              callback(null, result);
-            });
-          }
-          else {
-            callback(null, null);
-          }
+            callback(null, result);
+          });
+        }, function () {
+          cleanTmp();
+          switchToMaster();
 
-      }, function () {
-        cleanTmp();
-        switchToMaster();
-
-        logger.info('Finished updating all projects');
-        logger.close();
+          logger.info('Finished updating projects');
+          logger.close();
+        });
       });
     });
   });
@@ -59,17 +60,23 @@ function traverse(projectsPath, callback) {
   glob(path.join(projectsPath, '*', config.get('metadata-file')), callback);
 }
 
-function update(jsDelivrPath, metadataPath, callback) {
-  logger.debug('Updating using metadata' + metadataPath);
+// Determine all of the repos that should be updated (in parallel)
+function reduceReposToUpdate(paths, callback) {
+  async.mapLimit(paths, 20, project.check, function(projects) {
+    callback(null, _.filter(projects, 'updateRemote'));
+  });
+}
+
+function update(proj, jsDelivrPath, callback) {
+  logger.debug('Updating using metadata %s', proj.metadataPath);
 
   async.waterfall([
-    async.apply(project.check, metadataPath),
-    project.update,
+    async.apply(project.update, proj),
     async.apply(project.commit, jsDelivrPath),
     async.apply(project.pullRequest, jsDelivrPath)
   ], function (err, updateInfo) {
     if (err) {
-      logger.error('Failed to update project %s', metadataPath, { error: err });
+      logger.error('Failed to update project %s', proj.metadataPath, { error: err });
 
       return callback(err);
     }

--- a/lib/libgrabber.js
+++ b/lib/libgrabber.js
@@ -65,8 +65,9 @@ function traverse(projectsPath, callback) {
 
 // Determine all of the repos that should be updated (in parallel)
 function reduceReposToUpdate(paths, callback) {
-  async.mapLimit(paths, 20, project.check, function(err, projects) {
-    callback(err, _.filter(projects, 'updateRemote'));
+  async.mapLimit(paths, 15, project.check, function(err, projects) {
+    // Filter out the ones which error or don't need updates (no updateRemote)
+    callback(null, _.filter(projects, 'updateRemote'));
   });
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -26,7 +26,6 @@ var transports = [
   })
 ];
 
-
 if (papertrailUrl && papertrailHostname) {
   var host = papertrailUrl.split(':')[0];
   var port = papertrailUrl.split(':')[1];

--- a/lib/project.js
+++ b/lib/project.js
@@ -35,7 +35,8 @@ function check(metadataPath, callback) {
 
     var result = {
       metadata: metadata,
-      updateRemote: updateRemote
+      updateRemote: updateRemote,
+      metadataPath: metadataPath
     };
     if (updateRemote) {
       result.version = lastAvailable;

--- a/lib/project.js
+++ b/lib/project.js
@@ -15,10 +15,11 @@ var packageManagers = require('./packageManagers');
 var templates = require('./templates');
 
 function check(metadataPath, callback) {
+  logger.debug('Checking project at %s', metadataPath);
   metadata(metadataPath, function (err, metadata) {
     if (err) {
       logger.warn('Failed to read metadata', { metadataPath: metadataPath, error: err });
-      return callback(err);
+      return callback(null, null);
     }
     var fsVersion = _.last(metadata.localVersions);
     var branchVersion = _.last(metadata.branchVersions);
@@ -324,6 +325,7 @@ function pullRequest(jsDelivrPath, updateInfo, callback) {
           head: originRepo.user + ':' + updateInfo.branch,
           base: 'master'
         };
+        logger.debug(message);
         github.pullRequest(message, function (err, res) {
           if (err) {
             logger.error('Error in creating pull request', { error: err });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "handlebars": "^2.0.0-alpha.2",
     "js-beautify": "^1.4.2",
     "jsonfile": "^1.1.1",
-    "lodash": "~2.4.1",
+    "lodash": "^3.9.0",
     "mkdirp": "^0.3.5",
     "mocha": "^1.18.2",
     "nconf": "^0.6.9",


### PR DESCRIPTION
The idea is very straightforward: determine the repos that need to be synchronized (in parallel) before attempting the update - instead of doing the entire `check`, `update`, `push`, `pull_request` in series for each project when they can exit early due to no update being necessary.

P.s. I still havent tested this

/cc @UnbounDev