### PR TITLE
Update all missing project versions between the latest JsDelvr versio…

### DIFF
--- a/lib/libgrabber.js
+++ b/lib/libgrabber.js
@@ -9,11 +9,11 @@ var config = require('./config');
 var logger = require('./logger');
 var project = require('./project');
 
-function updateAll(jsDelivrPath, projectsPath,projectToUpdate) {
+function updateAll(jsDelivrPath, projectsPath, projectToUpdate) {
 
   var projectToUpdate_metaDataPath = null;
 
-  if(!projectToUpdate)
+  if (!projectToUpdate)
     logger.info('Updating all projects');
   else {
     logger.info('Updating project %s', projectToUpdate);
@@ -23,26 +23,26 @@ function updateAll(jsDelivrPath, projectsPath,projectToUpdate) {
   syncRepo(function () {
     traverse(projectsPath, function (err, metadataPaths) {
       if (err) {
-        logger.error('Traverse error', { error: err });
+        logger.error('Traverse error', {error: err});
 
         throw err;
       }
 
       if (projectToUpdate_metaDataPath) {
-        metadataPaths = _.filter(metadataPaths, function(path) {
+        metadataPaths = _.filter(metadataPaths, function (path) {
           return projectToUpdate_metaDataPath === path;
         });
       }
 
-      reduceReposToUpdate(metadataPaths, function(err, projects) {
+      reduceReposToUpdate(metadataPaths, function (err, projects) {
         if (err) {
           return logger.error(err);
         }
         async.eachSeries(projects, function (proj, callback) {
           update(jsDelivrPath, proj, function (err, result) {
             if (err) {
-                // suppress error from propagating and go on with the next project
-                logger.error('Failed to update project', { error: err });
+              // suppress error from propagating and go on with the next project
+              logger.error('Failed to update project', {error: err});
             }
 
             callback(null, result);
@@ -65,7 +65,7 @@ function traverse(projectsPath, callback) {
 
 // Determine all of the repos that should be updated (in parallel)
 function reduceReposToUpdate(paths, callback) {
-  async.mapLimit(paths, 15, project.check, function(err, projects) {
+  async.mapLimit(paths, 15, project.check, function (err, projects) {
     // Filter out the ones which error or don't need updates (no updateRemote)
     callback(null, _.filter(projects, 'updateRemote'));
   });
@@ -73,33 +73,41 @@ function reduceReposToUpdate(paths, callback) {
 
 function update(jsDelivrPath, proj, callback) {
   logger.debug('Updating using metadata %s', proj.metadataPath);
-  async.waterfall([
-    async.apply(project.update, proj),
-    async.apply(project.commit, jsDelivrPath),
-    async.apply(project.pullRequest, jsDelivrPath)
-  ], function (err, updateInfo) {
-    if (err) {
-      logger.error('Failed to update project %s', proj.metadataPath, { error: err });
+  var updates = [];
+  async.eachSeries(proj.versions, function (version, done) {
+    proj.version = version;
+    async.waterfall([
+      async.apply(project.update, proj),
+      async.apply(project.commit, jsDelivrPath),
+      async.apply(project.pullRequest, jsDelivrPath)
+    ], function (err, updateInfo) {
 
-      return callback(err);
-    }
+      if (err) {
+        logger.error('Failed to update project %s', proj.metadataPath, {error: err});
+        return done(err);
+      }
 
-    if (updateInfo.version && updateInfo.updated) {
-      logger.info('Updated project %s to %s', updateInfo.metadata.name, updateInfo.version, { updateInfo: updateInfo });
-    } else {
-      logger.info('Project %s not updated', updateInfo.metadata.name, { updateInfo: updateInfo });
-    }
+      if (updateInfo.version && updateInfo.updated) {
+        logger.info('Updated project %s to %s', updateInfo.metadata.name, updateInfo.version, {updateInfo: updateInfo});
+      }
+      else {
+        logger.info('Project %s not updated', updateInfo.metadata.name, {updateInfo: updateInfo});
+      }
 
-    return callback(null, updateInfo);
+      updates.push(updateInfo);
+      return done(null, updateInfo);
+    });
+  }, function (err) {
+    return callback(err, updates);
   });
 }
 
 function syncRepo(callback) {
   var repo = gift(config.get('jsdelivr-path'));
   repo.checkout('master', function () {
-    repo.remote_fetch('upstream', function() {
-      repo.git.cmd('reset', {}, ['--hard', 'upstream/master'], function () {
-        repo.git.cmd('push', {}, ['--force', 'origin', 'master'], function () {
+    repo.remote_fetch('upstream', function (err) {
+      repo.git.cmd('reset', {}, ['--hard', 'upstream/master'], function (err) {
+        repo.git.cmd('push', {}, ['--force', 'origin', 'master'], function (err) {
           callback(null);
         });
       });
@@ -109,7 +117,6 @@ function syncRepo(callback) {
 
 function cleanTmp() {
   var packageDir = config.get('tmp');
-
   remove(packageDir, _.noop);
 }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -37,10 +37,13 @@ function check(metadataPath, callback) {
     var result = {
       metadata: metadata,
       updateRemote: updateRemote,
-      metadataPath: metadataPath
+      metadataPath: metadataPath,
+      versions: []
     };
     if (updateRemote) {
-      result.version = lastAvailable;
+      result.versions = _.takeRightWhile(metadata.remoteVersions, function (version) {
+        return semverish.clean(version) !== lastInstalled;
+      });
     }
 
     callback(null, result);


### PR DESCRIPTION
…n and the latest Project Version.

In the event where a project owner publishes a major version update (e.g. 4.0.0)
and then a minor version update to a previous major version (e.g. 3.3.6),
libgrabber will miss the second published version as it only looked for the most recent project version.
This has been remedied.